### PR TITLE
Update MyStaticMeshComponent.cpp for 4.23

### DIFF
--- a/Source/UEPhysicsExample/MyStaticMeshComponent.cpp
+++ b/Source/UEPhysicsExample/MyStaticMeshComponent.cpp
@@ -113,7 +113,7 @@ void UMyStaticMeshComponent::DoPhysics(float DeltaTime, bool InSubstep)
 	float force = -(CurrError * owner->KSpring + Velocity * owner->Damping);
 
 	if (InSubstep) {
-		FPhysicsInterface::AddForce_AssumesLocked(*PActorHandle, FVector(0.0f, 0.f, force));
+		FPhysicsInterface::AddImpulse_AssumesLocked(*PActorHandle, FVector(0.0f, 0.f, force) * DeltaTime);
 	}
 	else {
 		AddForce(FVector(0.0f, 0.0f, force));


### PR DESCRIPTION
Updated for 4.23 in which AddForce_AssumesLocked is not available. Used AddImpulse_AssumesLocked instead, multiplying the force * DeltaTime.